### PR TITLE
remove ember deprecations warnings

### DIFF
--- a/generate/templates/client/app/templates/register.hbs
+++ b/generate/templates/client/app/templates/register.hbs
@@ -5,17 +5,17 @@
   <form {{action 'createUser' model on='submit' }}>
     <div>
       <label for="username">Username</label>
-      {{input id='username' placeholder='Enter your email' type='email' class='form-control' value=username}}
+      {{input id='username' placeholder='Enter your email' type='email' class='form-control' value=model.username}}
     </div>
     <div>
       <label for="password">Password</label>
-      {{input id='password' placeholder='Enter password' class='form-control' type='password' value=password}}
+      {{input id='password' placeholder='Enter password' class='form-control' type='password' value=model.password}}
     </div>
     <button type="submit">Register</button>
   </form>
   <div>
-    {{#if errorMessage}}
-      <strong>Registration failed:</strong>{{errorMessage}}
+    {{#if model.errorMessage}}
+      <strong>Registration failed:</strong>{{model.errorMessage}}
     {{/if}}
   </div>
 </div>


### PR DESCRIPTION
Example warning given was: 

```
"DEPRECATION: You attempted to access `errorMessage` from `(generated register controller)`, but object proxying is deprecated. Please use `model.errorMessage` instead. See http://emberjs.com/guides/deprecations
```
